### PR TITLE
Configures cbif to operate in mlab-staging

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,6 +17,6 @@ steps:
         grafana-public/app.yaml
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
   env:
-  - PROJECT_IN=mlab-sandbox
+  - PROJECT_IN=mlab-sandbox,mlab-staging
   args:
   - gcloud app deploy grafana-public/app.yaml --project $PROJECT_ID


### PR DESCRIPTION
Previously, `cbif` was only configured to deploy in mlab-sandbox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/3)
<!-- Reviewable:end -->
