### PR TITLE
Limit frequency of automatic refreshes

### DIFF
--- a/grafana-public/Dockerfile
+++ b/grafana-public/Dockerfile
@@ -10,6 +10,7 @@ ENV GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 ENV GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION="true"
 ENV GF_SERVER_HTTP_PORT="8080"
 ENV GF_USERS_HOME_PAGE="/d/1"
+ENV GF_DASHBOARDS_MIN_REFRESH_INTERVAL="1h"
 
 COPY dashboards/* /var/lib/grafana/dashboards/
 COPY provisioning/dashboards/* /etc/grafana/provisioning/dashboards/


### PR DESCRIPTION
This change sets the minimum refresh interval available in dashboards to 1hr.

From this:
<img width="554" alt="Screenshot 2024-03-04 at 12 44 39 PM" src="https://github.com/m-lab/visualizations/assets/1085316/d1807f6c-e957-4736-92b2-9853c8f13cfc">

To this:
<img width="398" alt="Screenshot 2024-03-04 at 12 44 54 PM" src="https://github.com/m-lab/visualizations/assets/1085316/50835377-eabc-44bd-8c29-14b4416d773c">

This change will still give users some options but limit re-query frequency for queries that could be complex.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/5)
<!-- Reviewable:end -->
