### PR TITLE
Uses Artifact Registry build images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,9 +4,17 @@ options:
   env:
   - PROJECT_ID=$PROJECT_ID
 
+# We have $_CONTAINER_IMAGE in a Cloud Build user-defined substitution variable
+# because this build gets run in more projects that just the standard
+# sandbox->staging->prod, but those projects are the only ones where the
+# container image is built and pushed to Artifact Registry. The other
+# production project where this build will happen is "measurement-lab", which
+# is a production project, so we want to use the "mlab-oti" (prod) image. The
+# value of this variable is defined in the build trigger of each project.
+#
 # Deploy public Grafana instance in AppEngine
 steps:
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
+- name: ${_CONTAINER_IMAGE}:1.1
   entrypoint: /bin/bash
   args:
   - -c
@@ -15,7 +23,7 @@ steps:
         -e 's|{{PROJECT_ID}}|${PROJECT_ID}|' \
         grafana-public/app.yaml.template > \
         grafana-public/app.yaml
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
+- name: ${_CONTAINER_IMAGE}:1.1
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,measurement-lab
   args:


### PR DESCRIPTION
And the name of the build image is stored as a user-defined substitution variable in the build trigger in each project. This is because the flow for this repo is mlab-sandbox -> mlab-staging -> measurement-lab, but the build images are not present in the measurement-lab project. That project uses the mlab-oti image, since both are production projects.