### PR TITLE
Adds adds a wait operation for deployments to measurement-lab

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,4 +33,6 @@ steps:
   env:
   - PROJECT_IN=measurement-lab
   args:
+  - gcloud app operations wait $(gcloud app operations list --format="value(id)" --pending --limit=1) || true
   - gcloud app deploy grafana-public/dispatch.yaml --project $PROJECT_ID
+


### PR DESCRIPTION
A production build failed with this error:

> Cannot operate on apps/measurement-lab because an operation is already in progress for apps/measurement-lab

Looking at the build step timing compared to the operations in App Engine, there is a very tight timing issue. This commit adds a new build step that waits for the most recent pending operation to complete before moving on to deploying dispatch.yaml. I _believe_ this should safeguard against this particular error condition in the build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/9)
<!-- Reviewable:end -->
