### PR TITLE
Adds a small sleep before deploying dispatch.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,6 +33,6 @@ steps:
   env:
   - PROJECT_IN=measurement-lab
   args:
-  - gcloud app operations wait $(gcloud app operations list --format="value(id)" --pending --limit=1) || true
+  - sleep 30 # Give all operations in previous step a few seconds to complete
   - gcloud app deploy grafana-public/dispatch.yaml --project $PROJECT_ID
 


### PR DESCRIPTION
@cristinaleonr: sorry for the waffling on this. The previous "fix" itself failed because there were no pending operations, and so the `gcloud app operations wait` command was given an empty operation ID, which threw an error. This change adds a simple sleep which should be completely adequate. The build and operations timing are apparently somewhat variable. I didn't catch this error before another production build because this particular step only runs in a production project.

-- 

A previous build of this repo in the measurement-lab failed on the step trying to deploy dispatch.yaml, and this was because the previous build step had triggered some operations that were still in progress when the dispatch.yaml step started, and app engine did not like this.

This change adds a 30s sleep before deploying dispatch.yaml just to be 100% sure that all app engine operations that the previous step triggered have completed. There is probably a more elegant solution using:

gcloud app operations wait

... but this would require basically a shell script as a build step, whereas a simple sleep should work just fine. The operations which caused the previous build failure completed just seconds after the dispatch.yaml had started, so 30s should be more than enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/10)
<!-- Reviewable:end -->
