### PR TITLE
Moves all production deployment to a single build step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,8 +11,8 @@ options:
 # production project where this build will happen is "measurement-lab", which
 # is a production project, so we want to use the "mlab-oti" (prod) image. The
 # value of this variable is defined in the build trigger of each project.
-#
-# Deploy public Grafana instance in AppEngine
+
+# Evaluate the app.yaml.template file
 steps:
 - name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif:1.1
   entrypoint: /bin/bash
@@ -23,16 +23,18 @@ steps:
         -e 's|{{PROJECT_ID}}|${PROJECT_ID}|' \
         grafana-public/app.yaml.template > \
         grafana-public/app.yaml
+
+# Deploy public Grafana instance in AppEngine in sandbox and staging
 - name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif:1.1
   env:
-  - PROJECT_IN=mlab-sandbox,mlab-staging,measurement-lab
+  - PROJECT_IN=mlab-sandbox,mlab-staging
   args:
   - gcloud app deploy grafana-public/app.yaml --project $PROJECT_ID
 
+# Deploy public Grafana instance in AppEngine in production
 - name: us-central1-docker.pkg.dev/${_IMAGE_PROJECT}/build-images/gcloud-jsonnet-cbif:1.1
   env:
   - PROJECT_IN=measurement-lab
   args:
-  - sleep 30 # Give all operations in previous step a few seconds to complete
-  - gcloud app deploy grafana-public/dispatch.yaml --project $PROJECT_ID
+  - gcloud app deploy grafana-public/app.yaml grafana-public/dispatch.yaml --project $PROJECT_ID
 


### PR DESCRIPTION
Previously, one build step would deploy app.yaml in production, and then a second build step would deploy dispatch.yaml. This was causing build failures on the 2nd step because even though the first build step completed as far as Cloud Build was concerned, GCP had launched some other operations in the background to promote the new deployment and deleted the old one. The second step was failing because gcloud wouldn't launch a new operation for the service while there were still operations in progress.

This change moves all production deployments steps to a single build step, and even more to a single invocation of `gcloud app deploy`. In this way, gcloud can decide when it it safe to deploy app.yaml and dispatch.yaml in relation to one another.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/11)
<!-- Reviewable:end -->
