### PR TITLE
Changed timepicker to be fixed at now-3d utc and hidden

### DIFF
--- a/grafana-public/dashboards/NDT7_World_Map.json
+++ b/grafana-public/dashboards/NDT7_World_Map.json
@@ -207,11 +207,14 @@
     ]
   },
   "time": {
-    "from": "now-7d",
-    "to": "now"
+    "from": "now-3d",
+    "to": "now-3d"
   },
-  "timepicker": {},
-  "timezone": "",
+  "timepicker": {
+    "hidden": true,
+    "nowDelay": ""
+  },
+  "timezone": "utc",
   "title": "NDT7 World Map",
   "uid": "1",
   "version": 13,


### PR DESCRIPTION
Prevent users from adjusting the grafana time range in unreasonable ways, which can cause excess BQ data consumption.

This version reads approximately 35GB of BQ data once on load, but has no controls to trigger additional queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/visualizations/14)
<!-- Reviewable:end -->
